### PR TITLE
v2.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change log
 
+## Version 2.0.4
+- 依存する Gradle のバージョンを更新
+- FunctionChannelを2.0.4に更新
+- テストプログラムの不具合を修正
+  - 実機で動作できるようにする (WebViewDataBusのインジェクション方式を自動から手動に変更)
+  - `MyClassJava` のアクセススコープがpublicではないためJavaScript側からインスタンス化できない問題を修正
+
 ## Version 2.0.3
 FunctionChannelをVersion 2.0.3に更新
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ ObjectChannelのAndroid用の実装を提供します。
 ### gradle
 ```
 dependencies {
-	compile 'jp.co.dwango.cbb:object-channel:2.0.3'
+	compile 'jp.co.dwango.cbb:object-channel:2.0.4'
 }
 ```
 

--- a/app/src/main/assets/html/index.html
+++ b/app/src/main/assets/html/index.html
@@ -1,6 +1,7 @@
 <html>
 <head>
     <meta name="viewport" content="width=480,user-scalable=no"/>
+    <script type="text/javascript">$(WEB-VIEW-DATA-BUS)</script>
     <script type="text/javascript" src="file:///android_asset/html/object-channel-wrapper.js"></script>
     <script type="text/javascript" src="file:///android_asset/html/script.js"></script>
 </head>

--- a/app/src/main/java/jp/co/dwango/cbb/oc/test/MainActivity.java
+++ b/app/src/main/java/jp/co/dwango/cbb/oc/test/MainActivity.java
@@ -55,7 +55,7 @@ public class MainActivity extends AppCompatActivity {
 		ObjectChannel.logging(true);
 
 		// DataBusを用いるWebViewを指定してインスタンス化
-		final DataBus dataBus = new WebViewDataBus(this, webView);
+		final WebViewDataBus dataBus = new WebViewDataBus(this, webView, true);
 
 		// ObjectChannelを作成
 		final ObjectChannelWrapper objectChannel = new ObjectChannelWrapper(dataBus);
@@ -144,7 +144,7 @@ public class MainActivity extends AppCompatActivity {
 		});
 
 		// WebView へコンテンツをロード
-		webView.loadDataWithBaseURL("", loadHtml("html/index.html"), "text/html", "UTF-8", null);
+		webView.loadDataWithBaseURL("", loadHtml("html/index.html").replace("$(WEB-VIEW-DATA-BUS)", dataBus.getInjectJavaScript()), "text/html", "UTF-8", null);
 	}
 
 	private String loadHtml(String path) {

--- a/app/src/main/java/jp/co/dwango/cbb/oc/test/MyClassJava.java
+++ b/app/src/main/java/jp/co/dwango/cbb/oc/test/MyClassJava.java
@@ -8,7 +8,7 @@ import jp.co.dwango.cbb.fc.AsyncResult;
 import jp.co.dwango.cbb.fc.CrossBorderMethod;
 import jp.co.dwango.cbb.oc.CrossBorderInterface;
 
-class MyClassJava implements CrossBorderInterface {
+public class MyClassJava implements CrossBorderInterface {
 	private final String c;
 
 	// constructorはアノテーションを付けなくてもよい（そもそも付けられない）

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0'
+        classpath 'com.android.tools.build:gradle:2.3.3'
     }
 }
 

--- a/object-channel/build.gradle
+++ b/object-channel/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'com.novoda.bintray-release'
-def pomVersion = "2.0.3"
+def pomVersion = "2.0.4"
 
 buildscript {
     repositories {
@@ -38,7 +38,7 @@ dependencies {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
     compile 'com.android.support:appcompat-v7:23.2.1'
-    compile 'jp.co.dwango.cbb:function-channel:2.0.3'
+    compile 'jp.co.dwango.cbb:function-channel:2.0.4'
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:1.9.5'
     testCompile 'org.json:json:20140107'


### PR DESCRIPTION
次の変更を実施
- 依存する Gradle のバージョンを更新
- FunctionChannelを2.0.4に更新
- テストプログラムの不具合を修正
  - 実機で動作できるようにする (WebViewDataBusのインジェクション方式を自動から手動に変更)
  - `MyClassJava` のアクセススコープがpublicではないためJavaScript側からインスタンス化できない問題を修正